### PR TITLE
Remove the unnecessary variable

### DIFF
--- a/src/test/java/dev/iomapper/IOMapNestedFunctionsTest.java
+++ b/src/test/java/dev/iomapper/IOMapNestedFunctionsTest.java
@@ -28,7 +28,7 @@ public class IOMapNestedFunctionsTest {
         numericModel.setByteField((byte) 127);
         numericModel.setShortField((short) 10000);
 
-        NumericDto numericDto = map.outer().from(numericModel).to(NumericDto.class).relate(customMapping ->
+        map.outer().from(numericModel).to(NumericDto.class).relate(customMapping ->
             customMapping.relate("nonexistentFunction(byteField, shortField)", "stringI")
         ).build();
     }


### PR DESCRIPTION
The variable is unnecessary because of It'll thrown an exception
of an invalid function call.